### PR TITLE
Editor3

### DIFF
--- a/src/component/editor/compose/index.module.css
+++ b/src/component/editor/compose/index.module.css
@@ -1,9 +1,0 @@
-.editor {
-  width: 100%;
-  font-size: 16px;
-  color: #261a3f;
-}
-
-span {
-  color: #261a3f;
-}

--- a/src/component/editor/compose/index.tsx
+++ b/src/component/editor/compose/index.tsx
@@ -1,3 +1,7 @@
+// @refresh reset - this comment:
+// - is local
+// - forces "react fast refresh" to remount all components defined in the file on every edit.
+// only affects development
 import React, { useMemo, useState } from "react";
 import { createEditor } from "slate";
 import { withHistory } from "slate-history";

--- a/src/component/editor/compose/index.tsx
+++ b/src/component/editor/compose/index.tsx
@@ -31,7 +31,7 @@ import {
   initialValueEmpty,
 } from "component/editor/config/initialValues";
 import { autoformatRules } from "component/editor/config/autoformatRules";
-import editorcss from "component/editor/compose/index.module.css";
+import actionbarcss from "component/plasmic/shared/PlasmicActionBar.module.css";
 
 const plugins = [
   ParagraphPlugin(options),
@@ -112,7 +112,7 @@ const ComposeEditor = (props: EditorProps) => {
       <EditablePlugins
         plugins={plugins}
         placeholder="Why does this matter?"
-        className={editorcss.editor}
+        className={actionbarcss.textContainer}
         spellCheck
       />
     </Slate>

--- a/src/component/editor/read/index.tsx
+++ b/src/component/editor/read/index.tsx
@@ -1,3 +1,4 @@
+// @refresh reset
 import React, { useMemo, useState } from "react";
 import { createEditor } from "slate";
 import { Slate, withReact } from "slate-react";


### PR DESCRIPTION
This pull request uses plasmic css modules instead of us using our own - which preserves plasmic as presentation layer for now.

The catch is that changing named elements in plasmic can break the css module import in our component.