### PR TITLE
editor4

### DIFF
--- a/src/component/editor/compose/index.tsx
+++ b/src/component/editor/compose/index.tsx
@@ -98,8 +98,6 @@ const ComposeEditor = (props: EditorProps) => {
   const [value, setValue] = useState(initialValue);
   const editor = useMemo(() => pipe(createEditor(), ...withPlugins), []);
 
-  console.log("compose editor value:", value);
-
   return (
     <Slate
       editor={editor}

--- a/src/component/editor/compose/index.tsx
+++ b/src/component/editor/compose/index.tsx
@@ -1,3 +1,4 @@
+// @refresh reset
 import React, { useMemo, useState } from "react";
 import { createEditor } from "slate";
 import { withHistory } from "slate-history";
@@ -96,6 +97,8 @@ const ComposeEditor = (props: EditorProps) => {
 
   const [value, setValue] = useState(initialValue);
   const editor = useMemo(() => pipe(createEditor(), ...withPlugins), []);
+
+  console.log("compose editor value:", value);
 
   return (
     <Slate

--- a/src/component/editor/compose/index.tsx
+++ b/src/component/editor/compose/index.tsx
@@ -1,4 +1,7 @@
-// @refresh reset
+// @refresh reset - this comment:
+// - is local
+// - forces "react fast refresh" to remount all components defined in the file on every edit.
+// only affects development
 import React, { useMemo, useState } from "react";
 import { createEditor } from "slate";
 import { withHistory } from "slate-history";

--- a/src/component/editor/read/index.tsx
+++ b/src/component/editor/read/index.tsx
@@ -1,3 +1,4 @@
+// @refresh reset
 import React, { useMemo, useState } from "react";
 import { createEditor } from "slate";
 import { Slate, withReact } from "slate-react";


### PR DESCRIPTION
Was running into a strange editor error when saving in editor with an existing state
- `Cannot find a descendant at path [1,0] in node:`
  - The selection state for slate is controlled separately from the value state, and if you pass it a value and the selection state is no longer valid, it will throw an exception.

Caused by [React Fast Refresh](https://reactnative.dev/docs/fast-refresh#tips) 

issue in Slate.js repository [documented here](https://github.com/ianstormtaylor/slate/issues/3477)

solution:
- `// @refresh reset` at the top of slate editor component