### PR TITLE
prevent javascript files in ci

### DIFF
--- a/.github/workflows/docker-ts.yaml
+++ b/.github/workflows/docker-ts.yaml
@@ -25,11 +25,6 @@ jobs:
       - name: "Install Ts Dependencies"
         run: |
           npm install
-          npm install prettier --global
-
-      - name: "Check Ts Formatting"
-        run: |
-          prettier -c $(find ./src/ -name "*.ts" -o -name "*.tsx")
 
       - name: "Build Ts Project"
         run: |

--- a/.github/workflows/typescript.yaml
+++ b/.github/workflows/typescript.yaml
@@ -29,7 +29,17 @@ jobs:
 
       - name: "Prevent Js Files"
         run: |
-          test -z $(find ./src/ -name "*.js")
+          if [[ $(find ./src/ -name "*.js") ]]; then
+            echo ".js files not allowed"
+            exit 1
+          fi
+
+      - name: "Check Git Project"
+        run: |
+          if [[ $(git status --porcelain) ]]; then
+            echo "dirty git project"
+            exit 1
+          fi
 
       - name: "Check Ts Formatting"
         run: |

--- a/.github/workflows/typescript.yaml
+++ b/.github/workflows/typescript.yaml
@@ -30,14 +30,14 @@ jobs:
       - name: "Prevent Js Files"
         run: |
           if [[ $(find ./src/ -name "*.js") ]]; then
-            echo ".js files not allowed"
+            echo "found .js files"
             exit 1
           fi
 
       - name: "Check Git Project"
         run: |
           if [[ $(git status --porcelain) ]]; then
-            echo "dirty git project"
+            echo "found dirty files"
             exit 1
           fi
 

--- a/.github/workflows/typescript.yaml
+++ b/.github/workflows/typescript.yaml
@@ -27,6 +27,10 @@ jobs:
           npm install
           npm install prettier --global
 
+      - name: "Prevent Js Files"
+        run: |
+          test -z $(find ./src/ -name "*.js")
+
       - name: "Check Ts Formatting"
         run: |
           prettier -c $(find ./src/ -name "*.ts" -o -name "*.tsx")


### PR DESCRIPTION
We agreed on not having `.js` files in our projects. Recently some tried to sneak in. In order to automate the verification we enhance the builds to catch such mistakes. Below you see that the first build was successful where the check to prevent `.js` files got introduced. That was fine. The second commit failed to build because I pushed a `.js` file. That shows that the check works. I reverted the malicious commit and we are good to go. 