### PR TITLE
add default actionbar store state

### DIFF
--- a/src/component/actionbar/index.tsx
+++ b/src/component/actionbar/index.tsx
@@ -31,7 +31,7 @@ function ActionBar(props: ActionBarProps) {
   const { updates, setUpdates } = props;
 
   // setting composeEditor value
-  const store = localStorage["composeEditor.content"];
+  const store = localStorage["composeEditor.content"] || "";
   const initialValue = store !== "" ? JSON.parse(store) : initialValueEmpty;
   const [value, setValue] = useState<SlateDocument>(initialValue);
 
@@ -59,7 +59,7 @@ function ActionBar(props: ActionBarProps) {
   return (
     <PlasmicActionBar
       content={hasContent}
-      error={"hasError"}
+      error={undefined}
       textContainer={{
         render: () => (
           <ComposeEditor


### PR DESCRIPTION
Fixes #42 

the error message is misleading.

It comes from assigning a variable to a value in localStorage that is undefined.

The fix was to define a fallback value ("")

I didn't see the error on my machine because I needed to clear localStorage to mimic your state.