### PR TITLE
fix typescript config bug

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -6,12 +6,8 @@
     "esModuleInterop": true,
     "forceConsistentCasingInFileNames": true,
     "isolatedModules": true,
-    "jsx": "react-jsx",
-    "lib": [
-      "dom",
-      "dom.iterable",
-      "esnext"
-    ],
+    "jsx": "react",
+    "lib": ["dom", "dom.iterable", "esnext"],
     "module": "esnext",
     "moduleResolution": "node",
     "noEmit": true,
@@ -21,7 +17,5 @@
     "strict": true,
     "target": "ES2019"
   },
-  "include": [
-    "src"
-  ]
+  "include": ["src"]
 }


### PR DESCRIPTION
Was getting error on npm start: "Cannot use JSX unless the '--jsx' flag is provided"

and the following SO post provided guidance: https://stackoverflow.com/questions/50432556/cannot-use-jsx-unless-the-jsx-flag-is-provided