### PR TITLE
Compare timeline slug with path for current timeline

### DIFF
--- a/src/component/app/TimelineRoutes.tsx
+++ b/src/component/app/TimelineRoutes.tsx
@@ -5,12 +5,13 @@ import { useParams } from "react-router-dom";
 import { Home } from "component/page/home";
 import { ITimelineContext, TimelineContext } from "context/TimelineContext";
 import { VentureContext } from "context/VentureContext";
+import { calculateNamedSlug } from "module/helpers";
 
 export function TimelineRoutes() {
   const { currentVentureTimelines } = useContext(VentureContext);
   const { timelineSlug } = useParams();
   const currentTimeline = currentVentureTimelines.find(
-    (t) => t.name === timelineSlug
+    (t) => calculateNamedSlug(t) === timelineSlug
   );
 
   const timelineContext: ITimelineContext = {


### PR DESCRIPTION
Fixes #376 

I found that this issue only applies to timelines where the slug doesn't match the name, such as those starting with a capital letter. I fixed it by comparing the timeline slug with the path to determine the current timeline for the timeline context.