### PR TITLE
Scroll sidebar to nearest side instead of center

### DIFF
--- a/src/component/sidebaritemgroup/index.tsx
+++ b/src/component/sidebaritemgroup/index.tsx
@@ -55,7 +55,7 @@ function SidebarItemGroup(props: SidebarItemGroupProps) {
     }
     if (el) {
       el.scrollIntoView({
-        block: "center",
+        block: "nearest",
       });
     }
   }, [currentTimeline, currentVenture, sortedVentureTimelines, ventureId]);


### PR DESCRIPTION
Fixes https://github.com/venturemark/webclient/issues/402

A value of `nearest` scrolls the parent container on the side where the element is relative to the parent such that the element is fully visible. If it is already visible, nothing will happen. This makes sure that the current timeline is visible when initially loading and clicking on a new timeline won't scroll the parent unless the timeline item is partially outside as expected.