### PR TITLE
Avoid JSON encoding title

### DIFF
--- a/src/component/actionbar/index.tsx
+++ b/src/component/actionbar/index.tsx
@@ -207,7 +207,7 @@ export default function ActionBar(props: ActionBarProps) {
 
     selectedTimelines.forEach((timelineId) => {
       createUpdate({
-        title: JSON.stringify({ type: "title", children: [{ text: title }] }),
+        title,
         text: JSON.stringify(editorShape.value),
         ventureId: currentVenture.id,
         timelineId: timelineId.id,


### PR DESCRIPTION
Originally I was using Slate for both the title and the description. Now we're using plain text for the title so we don't need to JSON encode it.