### PR TITLE
Handle and display server-side update creation error

### DIFF
--- a/src/component/actionbar/index.tsx
+++ b/src/component/actionbar/index.tsx
@@ -215,9 +215,7 @@ export default function ActionBar(props: ActionBarProps) {
               createUpdate(
                 {
                   title,
-                  text: JSON.stringify(
-                    editorShape.value.concat(editorShape.value)
-                  ),
+                  text: JSON.stringify(editorShape.value),
                   ventureId: currentVenture.id,
                   timelineId: timelineId.id,
                   token,


### PR DESCRIPTION
Displays error returned from server when creating an update fails. Also avoids clearing the editor so the user can edit the post instead of starting over.