### PR TITLE
[Issue #444] Remove second login screen

### DIFF
--- a/src/component/page/signin/index.tsx
+++ b/src/component/page/signin/index.tsx
@@ -7,6 +7,7 @@ import {
   PlasmicSignin,
 } from "component/plasmic/shared/PlasmicSignin";
 import { AuthContext } from "context/AuthContext";
+import { ProviderConnectionName } from "module/auth";
 
 interface SigninProps extends DefaultSigninProps {}
 
@@ -33,7 +34,13 @@ function Signin(props: SigninProps) {
   return (
     <PlasmicSignin
       googleButton={{
-        onPress: () => loginWithRedirect(redirectLoginOptions),
+        onPress: () => {
+          const options = {
+            ...redirectLoginOptions,
+            connection: ProviderConnectionName.google,
+          };
+          loginWithRedirect(options);
+        },
       }}
       linkedinButton={{
         onPress: () => alert("Linkedin inactive"),

--- a/src/module/auth/index.ts
+++ b/src/module/auth/index.ts
@@ -143,3 +143,7 @@ export function useAuth(): AuthState {
     token: token!,
   };
 }
+
+export const ProviderConnectionName = {
+  google: "google-oauth2",
+};


### PR DESCRIPTION
## Status
**READY**

## Issue links
https://github.com/venturemark/webclient/issues/444

## Description
Skip redirection to Auth0 Login Page by providing connection name

## Screen recording
https://user-images.githubusercontent.com/28189578/144998614-11f31ef9-e987-4c73-8fdf-1d5b9271d33a.mov
