### PR TITLE
Fix input text component

### DIFF
--- a/src/component/inputtext/index.tsx
+++ b/src/component/inputtext/index.tsx
@@ -3,10 +3,10 @@ import {
   PlumeTextFieldRef,
   useTextField,
 } from "@plasmicapp/plume";
+import { Flex } from "@plasmicapp/react-web";
 import { forwardRef, ReactNode } from "react";
 
 import { PlasmicInputText } from "component/plasmic/shared/PlasmicInputText";
-import { Flex } from "@plasmicapp/react-web";
 
 interface TextFieldProps extends PlumeTextFieldProps {
   name: string;

--- a/src/component/inputtext/index.tsx
+++ b/src/component/inputtext/index.tsx
@@ -6,6 +6,7 @@ import {
 import { forwardRef, ReactNode } from "react";
 
 import { PlasmicInputText } from "component/plasmic/shared/PlasmicInputText";
+import { Flex } from "@plasmicapp/react-web";
 
 interface TextFieldProps extends PlumeTextFieldProps {
   name: string;
@@ -45,6 +46,11 @@ function InputText_(
     delete input.defaultValue;
   }
 
+  // Plume expects the input element to be called textInput while the current Plasmic design
+  // calls it input2. This assigns the textInput overrides to input2 so that onChange and other
+  // props are passed correctly.
+  plumeProps.overrides.input2 = plumeProps.overrides.textInput as Flex<"input">;
+
   return (
     <PlasmicInputText
       {...plumeProps}
@@ -54,9 +60,6 @@ function InputText_(
       variants={{
         ...plumeProps.variants,
         error: message ? "error" : undefined,
-      }}
-      input2={{
-        props: { value: props.value },
       }}
     />
   );


### PR DESCRIPTION
Plume expects the input to be called inputText but it's called input2 in the current Plasmic design. This PR reassigns the overrides to handle this.