### PR TITLE
Add or replace visibility depending on existing value

### DIFF
--- a/src/component/addedittimeline/index.tsx
+++ b/src/component/addedittimeline/index.tsx
@@ -96,6 +96,7 @@ function AddEditTimeline(props: AddEditTimelineProps) {
           ventureId,
           successUrl: `/${ventureId}/${timelineId}/feed`,
           token,
+          previous: currentTimeline,
         },
         {
           onSuccess() {

--- a/src/module/api/timeline/update/index.ts
+++ b/src/module/api/timeline/update/index.ts
@@ -61,7 +61,7 @@ export async function Update(
 
   if (updateTimeline.visibility) {
     const patch = new UpdateI_Obj_Jsnpatch();
-    patch.setOpe("replace");
+    patch.setOpe(updateTimeline.previous?.visibility ? "replace" : "add");
     patch.setPat(`/obj/metadata/${key.ResourceVisibility.replace("/", "~1")}`);
     patch.setVal(updateTimeline.visibility);
     patchList.push(patch);

--- a/src/module/interface/timeline/index.ts
+++ b/src/module/interface/timeline/index.ts
@@ -50,4 +50,5 @@ export interface IUpdateTimeline {
   visibility?: string;
   successUrl?: string;
   token: string | null;
+  previous?: ITimeline;
 }


### PR DESCRIPTION
Fixes API error when first setting the visibility of a timeline.